### PR TITLE
Fix UI layout issue in tablet/desktop mode

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -28,7 +28,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background lg:flex">
       {/* Sidebar for desktop */}
       <Sidebar isOpen={!isMobile} />
 
@@ -36,9 +36,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       <MobileMenu isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       {/* Main content area */}
-      <div
-        className={`transition-all duration-300 ${!isMobile ? 'lg:ml-64' : ''}`}
-      >
+      <div className="flex-1 flex flex-col min-w-0">
         {/* Top navigation bar */}
         <header className="sticky top-0 z-40 border-b border-border bg-card/80 backdrop-blur-sm">
           <div className="flex h-16 items-center justify-between px-4">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ isOpen }: SidebarProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-y-0 left-0 z-50 w-64 transform bg-card border-r border-border transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0">
+    <div className="fixed inset-y-0 left-0 z-50 w-64 bg-card border-r border-border transition-transform duration-300 ease-in-out lg:relative lg:z-auto">
       <div className="flex h-full flex-col">
         {/* Logo/Brand */}
         <div className="flex h-16 items-center border-b border-border px-6">


### PR DESCRIPTION
## Summary
Fixed the UI layout issue where the left menu was causing the main content to be pushed down when in tablet or desktop mode.

## Problem
The issue was caused by conflicting CSS positioning properties:
- Sidebar had both `fixed` and `lg:static` positioning which created conflicts
- Main content area used `lg:ml-64` margin approach which didn't work properly with the mixed positioning
- The layout didn't properly utilize flexbox for desktop screen sizes

## Solution
- Changed the root container to use `lg:flex` for proper flexbox layout on desktop
- Updated sidebar positioning from conflicting `fixed` + `lg:static` to `fixed` + `lg:relative`
- Replaced main content margin approach with proper flexbox `flex-1` layout
- Added `min-w-0` to prevent text overflow issues in the flex container

## Changes Made
- **AppLayout.tsx**: Updated root container to use flexbox layout and simplified main content area
- **Sidebar.tsx**: Fixed positioning conflicts by using `lg:relative` instead of `lg:static lg:inset-0`

## Testing
- ✅ ESLint checks pass
- ✅ Tests pass with no regressions
- ✅ Codacy quality scans pass with no new issues
- ✅ Layout now works correctly across mobile, tablet, and desktop breakpoints

## Related Issue
Fixes #122

🤖 Generated with [Claude Code](https://claude.ai/code)