### PR TITLE
Fix incorrect reset password link (/auth/reset-password → /reset-password)

### DIFF
--- a/docs/NEXTAUTH_SETUP_GUIDE.md
+++ b/docs/NEXTAUTH_SETUP_GUIDE.md
@@ -282,7 +282,7 @@ After deployment, verify these authentication flows work:
    - Verify redirect to dashboard
 
 3. **Password Reset**:
-   - Visit `/auth/reset-password`
+   - Visit `/reset-password`
    - Enter email
    - Check email for reset link
    - Complete password reset

--- a/scripts/test-auth-flows.sh
+++ b/scripts/test-auth-flows.sh
@@ -70,7 +70,7 @@ echo "🔐 Testing Authentication Pages..."
 test_http_status "/auth/signin" 200 "Sign in page"
 test_http_status "/auth/signup" 200 "Sign up page"
 test_http_status "/auth/error" 200 "Auth error page"
-test_http_status "/auth/reset-password" 200 "Password reset page"
+test_http_status "/reset-password" 200 "Password reset page"
 
 echo ""
 echo "🚫 Testing Protected Routes (should require auth)..."

--- a/src/app/(auth)/__tests__/SignInPage.test.tsx
+++ b/src/app/(auth)/__tests__/SignInPage.test.tsx
@@ -53,6 +53,13 @@ describe('SignInPage Component', () => {
     expect(screen.getByText(/Don't have an account/i)).toBeInTheDocument();
   });
 
+  it('has correct reset password link', () => {
+    render(<SignInPage />);
+
+    const resetPasswordLink = screen.getByRole('link', { name: /Forgot password/i });
+    expect(resetPasswordLink).toHaveAttribute('href', '/reset-password');
+  });
+
   it('submits the form with valid credentials', async () => {
     render(<SignInPage />);
 

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -166,7 +166,7 @@ export default function SignInPage() {
             </Label>
           </div>
           <Link
-            href={'/auth/reset-password' as any}
+            href={'/reset-password' as any}
             className="text-sm text-primary hover:underline"
           >
             Forgot password?


### PR DESCRIPTION
## Summary
Fixed critical authentication bug where the "Forgot Password" link on the signin page was pointing to an incorrect URL, preventing users from accessing the password reset functionality.

### Changes Made
- **Fix signin page link**: Updated `/auth/reset-password` → `/reset-password` in `src/app/(auth)/signin/page.tsx:169`
- **Fix test script**: Updated test URL in `scripts/test-auth-flows.sh`  
- **Fix documentation**: Updated guide URL in `docs/NEXTAUTH_SETUP_GUIDE.md`
- **Add test coverage**: Added test case to verify correct reset password link

## Related Issue
**CLOSES: #269**

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] Added test case for correct reset password link
- [x] Verified signin page test passes
- [x] Confirmed link works correctly in UI
- [x] Updated test script validates correct URL
- [x] Build completes successfully

## Quality Assurance Checklist
- [x] Lint passes (`npm run lint:fix`)
- [x] Build succeeds (`npm run build`) 
- [x] Tests pass for affected components
- [x] No new code quality issues introduced (Codacy scan shows 0 issues for changed files)
- [x] Code follows project conventions and standards

## Impact Assessment
**High Impact Fix:**
- **Before**: Users clicking "Forgot Password" received 404 error
- **After**: Users can successfully access password reset functionality
- **Risk**: Low - Simple URL correction with comprehensive testing

**Files Changed:**
- `src/app/(auth)/signin/page.tsx` (1 line changed)
- `src/app/(auth)/__tests__/SignInPage.test.tsx` (test added)
- `scripts/test-auth-flows.sh` (1 line changed)  
- `docs/NEXTAUTH_SETUP_GUIDE.md` (1 line changed)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>