### PR TITLE
feat: optimize participant lookups with Map for O(1) performance

### DIFF
--- a/src/components/combat/utils/__tests__/__test-helpers__/combatTestHelpers.ts
+++ b/src/components/combat/utils/__tests__/__test-helpers__/combatTestHelpers.ts
@@ -352,7 +352,7 @@ export function generateApiTestCases() {
  */
 export function createEncounterWithManyParticipants(participantCount: number): IEncounter {
   const encounter = createActiveEncounter(1, 0);
-  
+
   // Create many participants
   encounter.participants = Array.from({ length: participantCount }, (_, i) => ({
     characterId: `participant-${i}`,
@@ -402,7 +402,7 @@ export function runPerformanceTest<T>(
  * Runs comparative performance test between small and large datasets
  */
 export function runComparativePerformanceTest<T>(
-  testFunction: (encounter: IEncounter) => T,
+  testFunction: (_encounter: IEncounter) => T,
   smallSize: number = 10,
   largeSize: number = 100
 ): void {

--- a/src/components/combat/utils/__tests__/exportUtils.test.ts
+++ b/src/components/combat/utils/__tests__/exportUtils.test.ts
@@ -96,6 +96,115 @@ describe('exportUtils', () => {
     });
   });
 
+  describe('performance optimization', () => {
+    it('should handle large numbers of participants efficiently', () => {
+      // Create encounter with many participants to test O(1) lookups
+      const encounter = createActiveEncounter(1, 0);
+      const participantCount = 100;
+
+      // Create many participants
+      encounter.participants = Array.from({ length: participantCount }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      // Create many initiative entries
+      encounter.combatState.initiativeOrder = Array.from({ length: participantCount }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      const startTime = performance.now();
+      const result = buildExportData(encounter);
+      const endTime = performance.now();
+
+      // Should complete in reasonable time (less than 100ms for 100 participants)
+      const executionTime = endTime - startTime;
+      expect(executionTime).toBeLessThan(100);
+
+      // Verify all participants are included
+      expect(result.initiativeOrder).toHaveLength(participantCount);
+      expect(result.initiativeOrder[0].name).toBe('Character 0');
+      expect(result.initiativeOrder[participantCount - 1].name).toBe(`Character ${participantCount - 1}`);
+    });
+
+    it('should maintain consistent performance with Map-based lookups', () => {
+      const smallEncounter = createActiveEncounter(1, 0);
+      smallEncounter.participants = Array.from({ length: 10 }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      smallEncounter.combatState.initiativeOrder = Array.from({ length: 10 }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      const largeEncounter = createActiveEncounter(1, 0);
+      largeEncounter.participants = Array.from({ length: 100 }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      largeEncounter.combatState.initiativeOrder = Array.from({ length: 100 }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      // Test with small dataset
+      const smallStartTime = performance.now();
+      buildExportData(smallEncounter);
+      const smallEndTime = performance.now();
+      const smallTime = smallEndTime - smallStartTime;
+
+      // Test with large dataset
+      const largeStartTime = performance.now();
+      buildExportData(largeEncounter);
+      const largeEndTime = performance.now();
+      const largeTime = largeEndTime - largeStartTime;
+
+      // With O(1) Map lookups, the large dataset should not be significantly slower
+      // Allow for some variance but it shouldn't be 10x slower
+      expect(largeTime).toBeLessThan(smallTime * 10);
+    });
+  });
+
   describe('createDownloadLink', () => {
     it('should create and trigger download', () => {
       const testData = { test: 'data' };

--- a/src/components/combat/utils/__tests__/shareUtils.test.ts
+++ b/src/components/combat/utils/__tests__/shareUtils.test.ts
@@ -65,7 +65,7 @@ describe('shareUtils', () => {
       // Verify all participants are included in output
       expect(result).toContain('Character 0');
       expect(result).toContain(`Character ${participantCount - 1}`);
-      
+
       // Count the number of lines - should have header + participantCount entries
       const lines = result.split('\n').filter(line => line.trim() !== '');
       expect(lines.length).toBe(participantCount + 1); // +1 for header

--- a/src/components/combat/utils/__tests__/shareUtils.test.ts
+++ b/src/components/combat/utils/__tests__/shareUtils.test.ts
@@ -6,7 +6,10 @@ import {
   createEncounterWithParticipants,
   createActiveEncounter,
   setupDOMMocks,
-  resetDOMMocks
+  resetDOMMocks,
+  createEncounterWithManyParticipants,
+  runPerformanceTest,
+  runComparativePerformanceTest
 } from './__test-helpers__/combatTestHelpers';
 
 describe('shareUtils', () => {
@@ -54,113 +57,22 @@ describe('shareUtils', () => {
 
   describe('performance optimization', () => {
     it('should handle large numbers of participants efficiently', () => {
-      // Create encounter with many participants to test O(1) lookups
-      const encounter = createActiveEncounter(1, 0);
       const participantCount = 100;
+      const encounter = createEncounterWithManyParticipants(participantCount);
 
-      // Create many participants
-      encounter.participants = Array.from({ length: participantCount }, (_, i) => ({
-        characterId: `participant-${i}`,
-        name: `Character ${i}`,
-        type: 'Player',
-        maxHitPoints: 20,
-        currentHitPoints: 15,
-        temporaryHitPoints: 0,
-        armorClass: 15,
-        initiative: 20 - i,
-        isPlayer: true,
-        isVisible: true,
-        notes: '',
-        conditions: []
-      }));
-
-      // Create many initiative entries
-      encounter.combatState.initiativeOrder = Array.from({ length: participantCount }, (_, i) => ({
-        participantId: `participant-${i}`,
-        initiative: 20 - i,
-        dexterity: 15,
-        hasActed: false
-      }));
-
-      const startTime = performance.now();
-      const result = buildShareText(encounter);
-      const endTime = performance.now();
-
-      // Should complete in reasonable time (less than 100ms for 100 participants)
-      const executionTime = endTime - startTime;
-      expect(executionTime).toBeLessThan(100);
+      const { result } = runPerformanceTest(() => buildShareText(encounter));
 
       // Verify all participants are included in output
       expect(result).toContain('Character 0');
       expect(result).toContain(`Character ${participantCount - 1}`);
-
+      
       // Count the number of lines - should have header + participantCount entries
       const lines = result.split('\n').filter(line => line.trim() !== '');
       expect(lines.length).toBe(participantCount + 1); // +1 for header
     });
 
     it('should maintain consistent performance with Map-based lookups', () => {
-      const smallEncounter = createActiveEncounter(1, 0);
-      smallEncounter.participants = Array.from({ length: 10 }, (_, i) => ({
-        characterId: `participant-${i}`,
-        name: `Character ${i}`,
-        type: 'Player',
-        maxHitPoints: 20,
-        currentHitPoints: 15,
-        temporaryHitPoints: 0,
-        armorClass: 15,
-        initiative: 20 - i,
-        isPlayer: true,
-        isVisible: true,
-        notes: '',
-        conditions: []
-      }));
-
-      smallEncounter.combatState.initiativeOrder = Array.from({ length: 10 }, (_, i) => ({
-        participantId: `participant-${i}`,
-        initiative: 20 - i,
-        dexterity: 15,
-        hasActed: false
-      }));
-
-      const largeEncounter = createActiveEncounter(1, 0);
-      largeEncounter.participants = Array.from({ length: 100 }, (_, i) => ({
-        characterId: `participant-${i}`,
-        name: `Character ${i}`,
-        type: 'Player',
-        maxHitPoints: 20,
-        currentHitPoints: 15,
-        temporaryHitPoints: 0,
-        armorClass: 15,
-        initiative: 20 - i,
-        isPlayer: true,
-        isVisible: true,
-        notes: '',
-        conditions: []
-      }));
-
-      largeEncounter.combatState.initiativeOrder = Array.from({ length: 100 }, (_, i) => ({
-        participantId: `participant-${i}`,
-        initiative: 20 - i,
-        dexterity: 15,
-        hasActed: false
-      }));
-
-      // Test with small dataset
-      const smallStartTime = performance.now();
-      buildShareText(smallEncounter);
-      const smallEndTime = performance.now();
-      const smallTime = smallEndTime - smallStartTime;
-
-      // Test with large dataset
-      const largeStartTime = performance.now();
-      buildShareText(largeEncounter);
-      const largeEndTime = performance.now();
-      const largeTime = largeEndTime - largeStartTime;
-
-      // With O(1) Map lookups, the large dataset should not be significantly slower
-      // Allow for some variance but it shouldn't be 10x slower
-      expect(largeTime).toBeLessThan(smallTime * 10);
+      runComparativePerformanceTest(buildShareText);
     });
   });
 

--- a/src/components/combat/utils/__tests__/shareUtils.test.ts
+++ b/src/components/combat/utils/__tests__/shareUtils.test.ts
@@ -52,6 +52,118 @@ describe('shareUtils', () => {
     });
   });
 
+  describe('performance optimization', () => {
+    it('should handle large numbers of participants efficiently', () => {
+      // Create encounter with many participants to test O(1) lookups
+      const encounter = createActiveEncounter(1, 0);
+      const participantCount = 100;
+
+      // Create many participants
+      encounter.participants = Array.from({ length: participantCount }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      // Create many initiative entries
+      encounter.combatState.initiativeOrder = Array.from({ length: participantCount }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      const startTime = performance.now();
+      const result = buildShareText(encounter);
+      const endTime = performance.now();
+
+      // Should complete in reasonable time (less than 100ms for 100 participants)
+      const executionTime = endTime - startTime;
+      expect(executionTime).toBeLessThan(100);
+
+      // Verify all participants are included in output
+      expect(result).toContain('Character 0');
+      expect(result).toContain(`Character ${participantCount - 1}`);
+
+      // Count the number of lines - should have header + participantCount entries
+      const lines = result.split('\n').filter(line => line.trim() !== '');
+      expect(lines.length).toBe(participantCount + 1); // +1 for header
+    });
+
+    it('should maintain consistent performance with Map-based lookups', () => {
+      const smallEncounter = createActiveEncounter(1, 0);
+      smallEncounter.participants = Array.from({ length: 10 }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      smallEncounter.combatState.initiativeOrder = Array.from({ length: 10 }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      const largeEncounter = createActiveEncounter(1, 0);
+      largeEncounter.participants = Array.from({ length: 100 }, (_, i) => ({
+        characterId: `participant-${i}`,
+        name: `Character ${i}`,
+        type: 'Player',
+        maxHitPoints: 20,
+        currentHitPoints: 15,
+        temporaryHitPoints: 0,
+        armorClass: 15,
+        initiative: 20 - i,
+        isPlayer: true,
+        isVisible: true,
+        notes: '',
+        conditions: []
+      }));
+
+      largeEncounter.combatState.initiativeOrder = Array.from({ length: 100 }, (_, i) => ({
+        participantId: `participant-${i}`,
+        initiative: 20 - i,
+        dexterity: 15,
+        hasActed: false
+      }));
+
+      // Test with small dataset
+      const smallStartTime = performance.now();
+      buildShareText(smallEncounter);
+      const smallEndTime = performance.now();
+      const smallTime = smallEndTime - smallStartTime;
+
+      // Test with large dataset
+      const largeStartTime = performance.now();
+      buildShareText(largeEncounter);
+      const largeEndTime = performance.now();
+      const largeTime = largeEndTime - largeStartTime;
+
+      // With O(1) Map lookups, the large dataset should not be significantly slower
+      // Allow for some variance but it shouldn't be 10x slower
+      expect(largeTime).toBeLessThan(smallTime * 10);
+    });
+  });
+
   describe('copyToClipboard', () => {
     it('should use navigator.clipboard when available', async () => {
       const testText = 'Test clipboard text';

--- a/src/components/combat/utils/exportUtils.ts
+++ b/src/components/combat/utils/exportUtils.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { IEncounter, IInitiativeEntry, IParticipantReference } from '@/lib/models/encounter/interfaces';
-import { findParticipantById } from './participantUtils';
 
 /**
  * Transforms an initiative entry for export
@@ -22,12 +21,17 @@ function transformInitiativeEntry(entry: IInitiativeEntry, participant: IPartici
  * Helper function to build export data
  */
 export function buildExportData(encounter: IEncounter) {
+  // Create a Map for O(1) participant lookups instead of O(n) array.find()
+  const participantMap = new Map(
+    encounter.participants.map(p => [p.characterId.toString(), p])
+  );
+
   return {
     encounterName: encounter.name,
     round: encounter.combatState.currentRound,
     turn: encounter.combatState.currentTurn,
     initiativeOrder: encounter.combatState.initiativeOrder.map(entry => {
-      const participant = findParticipantById(encounter.participants, entry.participantId.toString());
+      const participant = participantMap.get(entry.participantId.toString());
       return transformInitiativeEntry(entry, participant);
     }),
     exportedAt: new Date().toISOString()

--- a/src/components/combat/utils/shareUtils.ts
+++ b/src/components/combat/utils/shareUtils.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { IEncounter, IInitiativeEntry, IParticipantReference } from '@/lib/models/encounter/interfaces';
-import { findParticipantById } from './participantUtils';
 
 /**
  * Formats an individual initiative entry line
@@ -26,8 +25,13 @@ function formatInitiativeEntry(
 export function buildShareText(encounter: IEncounter): string {
   const header = `Initiative Order - ${encounter.name} (Round ${encounter.combatState.currentRound})\n\n`;
 
+  // Create a Map for O(1) participant lookups instead of O(n) array.find()
+  const participantMap = new Map(
+    encounter.participants.map(p => [p.characterId.toString(), p])
+  );
+
   const orderLines = encounter.combatState.initiativeOrder.map((entry, index) => {
-    const participant = findParticipantById(encounter.participants, entry.participantId.toString());
+    const participant = participantMap.get(entry.participantId.toString());
     return formatInitiativeEntry(entry, index, participant, encounter.combatState.currentTurn);
   }).join('\n');
 


### PR DESCRIPTION
## Summary
- Replace O(n) array.find() with O(1) Map lookups in buildExportData and buildShareText functions
- Performance improvement: reduces complexity from O(n*m) to O(n+m) where n is initiative order length and m is participants count
- Add comprehensive performance tests to verify optimization works correctly

## Related Issue
CLOSES: #227

## Type of Change
- [x] Performance improvement
- [x] Test coverage addition
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Added performance tests with 100 participants to verify O(1) lookup performance
- [x] Added comparative performance tests to ensure optimization is effective
- [x] All existing tests continue to pass
- [x] 100% test coverage maintained for modified files
- [x] Linting passes
- [x] Build succeeds

## Implementation Details
Created a `Map` using `characterId` as the key for each participant, allowing O(1) lookup time instead of O(n) array.find(). This optimization is particularly beneficial when encounters have large numbers of participants.

### Before (O(n*m) complexity):
```javascript
encounter.combatState.initiativeOrder.map(entry => {
  const participant = findParticipantById(encounter.participants, entry.participantId.toString());
  return transformInitiativeEntry(entry, participant);
});
```

### After (O(n+m) complexity):
```javascript
const participantMap = new Map(
  encounter.participants.map(p => [p.characterId.toString(), p])
);
encounter.combatState.initiativeOrder.map(entry => {
  const participant = participantMap.get(entry.participantId.toString());
  return transformInitiativeEntry(entry, participant);
});
```

🤖 Generated with [Claude Code](https://claude.ai/code)