### PR TITLE
fix: redirect auth middleware to /signin instead of /auth/signin

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -115,8 +115,8 @@ describe('Middleware Route Protection', () => {
       const publicRoutes = [
         '/',
         '/about',
-        '/auth/signin',
-        '/auth/signup',
+        '/signin',
+        '/signup',
         '/auth/error',
         '/api/health',
       ];
@@ -162,7 +162,7 @@ describe('Middleware Route Protection', () => {
       });
       expect(mockRedirect).toHaveBeenCalledWith(
         expect.objectContaining({
-          href: expect.stringContaining('/auth/signin'),
+          href: expect.stringContaining('/signin'),
           searchParams: expect.any(Object),
         })
       );
@@ -180,7 +180,7 @@ describe('Middleware Route Protection', () => {
 
       // Mock URL constructor and redirect
       const mockUrl = {
-        href: 'http://localhost:3000/auth/signin?callbackUrl=http%3A//localhost%3A3000/dashboard/characters',
+        href: 'http://localhost:3000/signin?callbackUrl=http%3A//localhost%3A3000/dashboard/characters',
         searchParams: {
           set: jest.fn(),
         },
@@ -330,7 +330,7 @@ describe('Middleware Route Protection', () => {
   });
 
   describe('URL Construction', () => {
-    it('should construct signin URL correctly', async () => {
+    it('should construct signin URL correctly with /signin path', async () => {
       const { middleware } = await import('../middleware');
 
       const request = {
@@ -342,7 +342,7 @@ describe('Middleware Route Protection', () => {
 
       // Mock URL to track constructor calls
       const mockUrl = {
-        href: 'http://localhost:3000/auth/signin',
+        href: 'http://localhost:3000/signin',
         searchParams: {
           set: jest.fn(),
         },
@@ -350,7 +350,7 @@ describe('Middleware Route Protection', () => {
 
       const originalURL = global.URL;
       global.URL = jest.fn().mockImplementation((path, base) => {
-        expect(path).toBe('/auth/signin');
+        expect(path).toBe('/signin');
         expect(base).toBe('http://localhost:3000/dashboard');
         return mockUrl;
       }) as any;
@@ -360,7 +360,7 @@ describe('Middleware Route Protection', () => {
       await middleware(request);
 
       expect(global.URL).toHaveBeenCalledWith(
-        '/auth/signin',
+        '/signin',
         'http://localhost:3000/dashboard'
       );
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -91,7 +91,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
   pages: {
-    signIn: '/auth/signin',
+    signIn: '/signin',
     error: '/auth/error',
   },
   debug: process.env.NODE_ENV === 'development',

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -107,7 +107,7 @@ export function useRequireAuth(options: RequireAuthOptions = {}): {
 
   useEffect(() => {
     if (status === 'unauthenticated') {
-      const redirectTo = options.redirectTo || '/auth/signin';
+      const redirectTo = options.redirectTo || '/signin';
       performRedirect(router, redirectTo, options.replace);
     }
   }, [status, router, options]);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,7 +38,7 @@ export async function middleware(request: NextRequest) {
     }
 
     // For page routes, redirect to signin with callback URL
-    const url = new URL('/auth/signin', request.url);
+    const url = new URL('/signin', request.url);
     url.searchParams.set('callbackUrl', encodeURI(request.url));
     return NextResponse.redirect(url);
   }


### PR DESCRIPTION
## Summary
Fix authentication middleware redirect to point to `/signin` instead of `/auth/signin` which was causing 404 errors for unauthenticated users.

## Changes Made
- Updated `middleware.ts` to redirect to `/signin` instead of `/auth/signin`
- Updated NextAuth configuration in `auth.ts` to use correct signin page path
- Updated `session-client.ts` default redirect path to `/signin`
- Updated test expectations to match correct redirect behavior

## Related Issue
CLOSES: #360

## Test Plan
- ✅ Updated existing middleware tests to expect correct redirect path
- ✅ All tests pass with new redirect behavior
- ✅ ESLint and build checks pass
- ✅ Verified signin page exists at `/signin` route

## Quality Checks
- ✅ ESLint: No warnings or errors
- ✅ TypeScript: Compilation successful
- ✅ Tests: All middleware tests pass
- ✅ Build: Production build successful

🤖 Generated with [Claude Code](https://claude.ai/code)