### PR TITLE
Fix auth error page redirect path - Issue #363

### DIFF
--- a/codacy-detailed-results.json
+++ b/codacy-detailed-results.json
@@ -1,0 +1,75 @@
+                    
+                    
+┌──────────────────┐
+│ 22 Code Findings │
+└──────────────────┘
+                                                                 
+    src/lib/services/__tests__/PasswordHashingIntegration.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           68┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           97┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+          117┆ const shortPassword = 'short';
+            ⋮┆----------------------------------------
+          223┆ const password = 'TestSaltRounds123!';
+            ⋮┆----------------------------------------
+          274┆ const password = 'SecurityCompliantPassword123!';
+                                                                  
+    src/lib/services/__tests__/PasswordHashingVerification.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           14┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           37┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           45┆ const strongPassword = 'StrongPassword123!';
+            ⋮┆----------------------------------------
+           46┆ const weakPassword = 'weak';
+            ⋮┆----------------------------------------
+           62┆ const plainPassword = 'AuthTestPassword123!';
+            ⋮┆----------------------------------------
+           77┆ const originalPassword = 'OriginalPassword123!';
+            ⋮┆----------------------------------------
+           78┆ const newPassword = 'NewPassword123!';
+            ⋮┆----------------------------------------
+          127┆ const password = 'SaltTestPassword123!';
+                                                              
+    src/lib/services/__tests__/RealPasswordHashingTest.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           16┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           45┆ const plainPassword = 'DirectBcryptTest123!';
+            ⋮┆----------------------------------------
+           95┆ const plainPassword = 'ReportTest123!';
+                                                                        
+    src/lib/services/__tests__/UserServiceDatabase.comprehensive.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+          449┆ const newPassword = 'NewPassword123!';
+                                                     
+    src/lib/utils/__tests__/password-security.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           12┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           33┆ const hashedPassword = '$2b$12$W/6WPGC5/e.M2vtQEpusM.0ltMcd1DeZUzqQ5LxJ.W7iRsyp0zZNm';
+            ⋮┆----------------------------------------
+           47┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           64┆ const hashedPassword = '$2b$12$hashedPasswordExample.hash.here.example';
+            ⋮┆----------------------------------------
+          193┆ const plainPassword = 'SecureTestPassword123!';
+

--- a/codacy-scan-results.json
+++ b/codacy-scan-results.json
@@ -1,0 +1,75 @@
+                    
+                    
+┌──────────────────┐
+│ 22 Code Findings │
+└──────────────────┘
+                                                                 
+    src/lib/services/__tests__/PasswordHashingIntegration.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           68┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           97┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+          117┆ const shortPassword = 'short';
+            ⋮┆----------------------------------------
+          223┆ const password = 'TestSaltRounds123!';
+            ⋮┆----------------------------------------
+          274┆ const password = 'SecurityCompliantPassword123!';
+                                                                  
+    src/lib/services/__tests__/PasswordHashingVerification.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           14┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           37┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           45┆ const strongPassword = 'StrongPassword123!';
+            ⋮┆----------------------------------------
+           46┆ const weakPassword = 'weak';
+            ⋮┆----------------------------------------
+           62┆ const plainPassword = 'AuthTestPassword123!';
+            ⋮┆----------------------------------------
+           77┆ const originalPassword = 'OriginalPassword123!';
+            ⋮┆----------------------------------------
+           78┆ const newPassword = 'NewPassword123!';
+            ⋮┆----------------------------------------
+          127┆ const password = 'SaltTestPassword123!';
+                                                              
+    src/lib/services/__tests__/RealPasswordHashingTest.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           16┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           45┆ const plainPassword = 'DirectBcryptTest123!';
+            ⋮┆----------------------------------------
+           95┆ const plainPassword = 'ReportTest123!';
+                                                                        
+    src/lib/services/__tests__/UserServiceDatabase.comprehensive.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+          449┆ const newPassword = 'NewPassword123!';
+                                                     
+    src/lib/utils/__tests__/password-security.test.ts
+   ❯❯❱ codacy.tools-configs.codacy.javascript.security.hard-coded-password
+          Hardcoded passwords are a security risk. They can be easily found by attackers and used to gain
+          unauthorized access to the system.                                                             
+                                                                                                         
+           12┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           33┆ const hashedPassword = '$2b$12$W/6WPGC5/e.M2vtQEpusM.0ltMcd1DeZUzqQ5LxJ.W7iRsyp0zZNm';
+            ⋮┆----------------------------------------
+           47┆ const plainPassword = 'TestPassword123!';
+            ⋮┆----------------------------------------
+           64┆ const hashedPassword = '$2b$12$hashedPasswordExample.hash.here.example';
+            ⋮┆----------------------------------------
+          193┆ const plainPassword = 'SecureTestPassword123!';
+

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -433,12 +433,12 @@ describe('Authentication System', () => {
 
     it('should have correct page configuration', () => {
       const expectedPages = {
-        signIn: '/auth/signin',
-        error: '/auth/error',
+        signIn: '/signin',
+        error: '/error',
       };
 
-      expect(expectedPages.signIn).toBe('/auth/signin');
-      expect(expectedPages.error).toBe('/auth/error');
+      expect(expectedPages.signIn).toBe('/signin');
+      expect(expectedPages.error).toBe('/error');
     });
 
     it('should handle debug mode based on environment', () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -92,7 +92,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
   pages: {
     signIn: '/signin',
-    error: '/auth/error',
+    error: '/error',
   },
   debug: process.env.NODE_ENV === 'development',
 });


### PR DESCRIPTION
Fixes the incorrect auth error page redirect path in NextAuth configuration.

## Summary
- Updates  configuration from  to  in 
- The  route group does not contribute to URL paths, so the error page is correctly at 

## Changes Made
- Fixed NextAuth pages configuration to use correct error page path

## Testing
- Error page redirect will now work correctly instead of causing 404 errors

CLOSES: #363