### PR TITLE
fix: handle 409 status codes in registration form

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -63,8 +63,8 @@ export default function SignUpPage() {
       const result = await response.json();
 
       if (!response.ok) {
-        // Handle server validation errors
-        if (response.status === 400 && result.errors) {
+        // Handle server validation errors (400) and duplicate user errors (409)
+        if ((response.status === 400 || response.status === 409) && result.errors) {
           setFormState({
             success: false,
             errors: result.errors.map((err: any) => ({


### PR DESCRIPTION
## Summary
- Frontend now properly handles both 400 and 409 status codes in registration form
- Users will see error messages for duplicate email/username instead of silent failures
- Fixes the issue where UserAlreadyExistsError (409) was not handled by frontend

## Related Issue
CLOSES: #417

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- Updated error handling logic in src/app/(auth)/signup/page.tsx:65-77
- Frontend now handles both 400 (validation errors) and 409 (duplicate user errors)
- Error messages will be properly displayed to users

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Comments added to hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Related documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)