### PR TITLE
Fix profile creation failing silently when user session is invalid

### DIFF
--- a/src/app/(auth)/__tests__/ProfileSetupPage.test.tsx
+++ b/src/app/(auth)/__tests__/ProfileSetupPage.test.tsx
@@ -177,4 +177,29 @@ describe('ProfileSetupPage Component', () => {
 
     expect(mockRouter.push).toHaveBeenCalledWith('/dashboard');
   });
+
+  it('shows error when user session has no ID', async () => {
+    // Mock session without user ID
+    (useSession as jest.Mock).mockReturnValue({
+      data: {
+        user: {
+          email: 'test@example.com',
+          name: 'John Doe',
+          // No ID property
+        },
+      },
+      status: 'authenticated',
+    });
+
+    render(<ProfileSetupPage />);
+
+    await fillProfileFormField(/Display Name/i, 'Test User');
+    await clickCompleteSetupButton();
+
+    await waitFor(() => {
+      expect(screen.getByText('User session not found')).toBeInTheDocument();
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /Complete Setup/i })).toBeEnabled();
+    });
+  });
 });

--- a/src/app/(auth)/profile-setup/components.tsx
+++ b/src/app/(auth)/profile-setup/components.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { User, CheckCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { User, CheckCircle, AlertCircle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
   FormWrapper,
@@ -188,9 +189,20 @@ export function ProfileForm({
   isSubmitting,
   errors,
 }: ProfileFormProps) {
+  // Find general errors (not tied to specific fields)
+  const generalError = errors.find(err => !err.field)?.message;
+
   return (
     <div className="space-y-6">
       <ProfileFormHeader />
+
+      {generalError && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{generalError}</AlertDescription>
+        </Alert>
+      )}
+
       <FormWrapper
         onSubmit={handleSubmit}
         errors={errors}


### PR DESCRIPTION
## Summary

Fixes profile creation form that was failing silently when user session has no ID. The form now properly displays general error messages to users.

## Changes Made

- **Added Alert component import** for error display
- **Added general error display logic** in ProfileForm component  
- **Added test case** for missing user ID scenario
- **Fixed silent failure** when user session is invalid

## Technical Details

- Follows established error display pattern from signin page
- Uses `Alert` component with `destructive` variant for errors
- Displays errors with empty `field` property above the form
- Maintains existing field-specific error handling

## Related Issue

Closes #443

## Test Plan

- [x] All existing tests pass
- [x] New test case for missing user ID passes
- [x] Build completes successfully
- [x] Linting passes
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>