### PR TITLE
Remove ESLint rule preventing 2015+ usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,13 @@ export default [
   ...compat.extends('prettier'),
   {
     languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
       globals: { // eslint-disable-line
         // Node.js globals // eslint-disable-line
         require: 'readonly', // eslint-disable-line
@@ -73,6 +80,8 @@ export default [
   {
     files: ['**/__tests__/**/*.{js,jsx,ts,tsx}', '**/*.{test,spec}.{js,jsx,ts,tsx}'], // eslint-disable-line
     languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
       globals: { // eslint-disable-line
         // Jest globals // eslint-disable-line
         describe: 'readonly', // eslint-disable-line
@@ -97,6 +106,8 @@ export default [
   {
     files: ['migrations/**/*.js'], // eslint-disable-line
     languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
       globals: { // eslint-disable-line
         // Node.js global variables for migration files // eslint-disable-line
         require: 'readonly', // eslint-disable-line
@@ -114,6 +125,8 @@ export default [
   {
     files: ['**/__mocks__/**/*.{js,jsx,ts,tsx}'], // eslint-disable-line
     languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
       globals: { // eslint-disable-line
         // Jest globals for mocks // eslint-disable-line
         jest: 'readonly', // eslint-disable-line

--- a/src/__tests__/es2015-features.test.ts
+++ b/src/__tests__/es2015-features.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Test file to verify ES2015+ (ES6+) features work correctly in the codebase
+ * This test demonstrates various ES2015+ features that should be allowed by ESLint
+ */
+
+describe('ES2015+ Features Support', () => {
+  test('arrow functions work correctly', () => {
+    const add = (a: number, b: number) => a + b;
+    expect(add(2, 3)).toBe(5);
+  });
+
+  test('const and let declarations work', () => {
+    const immutable = 'test';
+    let mutable = 'initial';
+    mutable = 'changed';
+
+    expect(immutable).toBe('test');
+    expect(mutable).toBe('changed');
+  });
+
+  test('template literals work correctly', () => {
+    const name = 'World';
+    const greeting = `Hello, ${name}!`;
+    expect(greeting).toBe('Hello, World!');
+  });
+
+  test('destructuring assignment works', () => {
+    const obj = { x: 1, y: 2, z: 3 };
+    const { x, y } = obj;
+    const arr = [1, 2, 3];
+    const [first, second] = arr;
+
+    expect(x).toBe(1);
+    expect(y).toBe(2);
+    expect(first).toBe(1);
+    expect(second).toBe(2);
+  });
+
+  test('spread operator works', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [...arr1, 4, 5];
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { ...obj1, c: 3 };
+
+    expect(arr2).toEqual([1, 2, 3, 4, 5]);
+    expect(obj2).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  test('default parameters work', () => {
+    const greet = (name = 'Anonymous') => `Hello, ${name}!`;
+    expect(greet()).toBe('Hello, Anonymous!');
+    expect(greet('John')).toBe('Hello, John!');
+  });
+
+  test('classes work correctly', () => {
+    class TestClass {
+      private value: number;
+
+      constructor(initialValue = 0) {
+        this.value = initialValue;
+      }
+
+      getValue(): number {
+        return this.value;
+      }
+
+      increment(): void {
+        this.value++;
+      }
+    }
+
+    const instance = new TestClass(5);
+    expect(instance.getValue()).toBe(5);
+    instance.increment();
+    expect(instance.getValue()).toBe(6);
+  });
+
+  test('for...of loops work', () => {
+    const numbers = [1, 2, 3, 4, 5];
+    const doubled: number[] = [];
+
+    for (const num of numbers) {
+      doubled.push(num * 2);
+    }
+
+    expect(doubled).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  test('Map and Set work correctly', () => {
+    const map = new Map([['key1', 'value1'], ['key2', 'value2']]);
+    const set = new Set([1, 2, 3, 2, 1]);
+
+    expect(map.get('key1')).toBe('value1');
+    expect(set.size).toBe(3);
+    expect(Array.from(set)).toEqual([1, 2, 3]);
+  });
+
+  test('Promises work correctly', async () => {
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('resolved'), 10);
+    });
+
+    const result = await promise;
+    expect(result).toBe('resolved');
+  });
+
+  test('async/await syntax works', async () => {
+    const fetchData = async (): Promise<string> => {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve('data'), 10);
+      });
+    };
+
+    const data = await fetchData();
+    expect(data).toBe('data');
+  });
+
+  test('object shorthand property works', () => {
+    const name = 'test';
+    const value = 42;
+    const obj = { name, value };
+
+    expect(obj).toEqual({ name: 'test', value: 42 });
+  });
+
+  test('computed property names work', () => {
+    const key = 'dynamic';
+    const obj = {
+      [key]: 'value',
+      [`${key}2`]: 'value2'
+    };
+
+    expect(obj.dynamic).toBe('value');
+    expect(obj.dynamic2).toBe('value2');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "es6"],
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "es2015", "es2017", "es2020"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary

Updates ESLint and TypeScript configurations to properly support ES2015+ (ES6+) features and patterns.

## Changes Made

- **TypeScript Configuration**: Updated `tsconfig.json` target from `es5` to `es2015` and expanded lib to include `es2015`, `es2017`, `es2020`
- **ESLint Configuration**: Added `ecmaVersion: 2022` and `sourceType: 'module'` with JSX support across all file configurations
- **Comprehensive Testing**: Added `es2015-features.test.ts` to validate all ES2015+ features work correctly
- **Consistent Configuration**: Applied modern JavaScript settings to test files, migration files, and mock files

## Features Validated

✅ Arrow functions and const/let declarations  
✅ Template literals and destructuring assignment  
✅ Spread operator and default parameters  
✅ ES6 classes and for...of loops  
✅ Map/Set collections and Promises  
✅ Async/await syntax and object shorthand  
✅ Computed property names  

## Testing

- All existing tests continue to pass
- New comprehensive ES2015+ feature test suite added
- Build process verified to work with updated configurations
- TypeScript compilation successful with new target

## Quality Assurance

- ESLint scan shows no issues with new configuration
- Code formatting automatically applied
- All modern JavaScript patterns now properly supported

CLOSES: #469

🤖 Generated with [Claude Code](https://claude.ai/code)