### PR TITLE
Add toast notifications for login success and failure (Issue #470)

### DIFF
--- a/src/app/(auth)/__tests__/SignInPage.test.tsx
+++ b/src/app/(auth)/__tests__/SignInPage.test.tsx
@@ -34,6 +34,39 @@ describe('SignInPage Component', () => {
     get: jest.fn(),
   };
 
+  // Test helper functions to reduce code duplication
+  const setupMockSearchParams = (callbackUrl: string | null = '/dashboard', error: string | null = null, next: string | null = null) => {
+    mockSearchParams.get.mockImplementation(param => {
+      if (param === 'callbackUrl') return callbackUrl;
+      if (param === 'error') return error;
+      if (param === 'next') return next;
+      return null;
+    });
+  };
+
+  const fillAndSubmitLoginForm = async (email = 'user@example.com', password = 'Password123!') => {
+    await userEvent.type(screen.getByLabelText(/Email/i), email);
+    await userEvent.type(screen.getByLabelText(/Password/i), password);
+    await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+  };
+
+  const expectToastCall = (title: string, variant: 'default' | 'destructive' = 'default') => {
+    expect(mockToast).toHaveBeenCalledWith({
+      title,
+      variant
+    });
+  };
+
+  const expectSuccessfulLogin = (redirectUrl = '/dashboard') => {
+    expectToastCall('Login Success');
+    expect(mockRouter.push).toHaveBeenCalledWith(redirectUrl);
+  };
+
+  const expectFailedLogin = () => {
+    expectToastCall('Login Failure, please check your email and password', 'destructive');
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
@@ -42,11 +75,7 @@ describe('SignInPage Component', () => {
     mockToast.mockClear();
 
     // Default mock implementation for searchParams.get
-    mockSearchParams.get.mockImplementation(param => {
-      if (param === 'callbackUrl') return '/dashboard';
-      if (param === 'error') return null;
-      return null;
-    });
+    setupMockSearchParams();
   });
 
   it('renders the signin form correctly', () => {
@@ -73,9 +102,7 @@ describe('SignInPage Component', () => {
   it('submits the form with valid credentials', async () => {
     render(<SignInPage />);
 
-    await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-    await userEvent.type(screen.getByLabelText(/Password/i), 'Password123!');
-    await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+    await fillAndSubmitLoginForm();
 
     await waitFor(() => {
       expect(signIn).toHaveBeenCalledWith('credentials', {
@@ -103,10 +130,7 @@ describe('SignInPage Component', () => {
 
   it('displays authentication error from URL parameter', async () => {
     // Mock error parameter in URL
-    mockSearchParams.get.mockImplementation(param => {
-      if (param === 'error') return 'CredentialsSignin';
-      return null;
-    });
+    setupMockSearchParams(null, 'CredentialsSignin');
 
     render(<SignInPage />);
 
@@ -122,12 +146,7 @@ describe('SignInPage Component', () => {
 
     render(<SignInPage />);
 
-    await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-    await userEvent.type(
-      screen.getByLabelText(/Password/i),
-      'WrongPassword123!'
-    );
-    await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+    await fillAndSubmitLoginForm('user@example.com', 'WrongPassword123!');
 
     await waitFor(() => {
       expect(screen.getByText('Invalid email or password')).toBeInTheDocument();
@@ -138,13 +157,7 @@ describe('SignInPage Component', () => {
   describe('Redirect Message Display', () => {
     // Helper function to mock search params and test redirect messages
     const testRedirectMessage = (url: string, expectedMessage: string, _description?: string) => {
-      mockSearchParams.get.mockImplementation(param => {
-        if (param === 'callbackUrl') return url;
-        if (param === 'next') return null;
-        if (param === 'error') return null;
-        return null;
-      });
-
+      setupMockSearchParams(url);
       render(<SignInPage />);
       expect(screen.getByText(expectedMessage)).toBeInTheDocument();
     };
@@ -192,12 +205,7 @@ describe('SignInPage Component', () => {
 
     it('shows redirect message when next parameter contains a protected route', () => {
       // Mock next parameter instead of callbackUrl
-      mockSearchParams.get.mockImplementation(param => {
-        if (param === 'callbackUrl') return null;
-        if (param === 'next') return '/settings';
-        if (param === 'error') return null;
-        return null;
-      });
+      setupMockSearchParams(null, null, '/settings');
 
       render(<SignInPage />);
 
@@ -205,16 +213,13 @@ describe('SignInPage Component', () => {
     });
 
     it('does not show redirect message when no redirect URL is provided', () => {
-      mockSearchParams.get.mockImplementation(_param => null);
+      setupMockSearchParams(null, null, null);
       render(<SignInPage />);
       expect(screen.queryByText(/Please sign in to view your/)).not.toBeInTheDocument();
     });
 
     it('does not show redirect message when callbackUrl points to default dashboard', () => {
-      mockSearchParams.get.mockImplementation(param => {
-        if (param === 'callbackUrl') return '/dashboard';
-        return null;
-      });
+      setupMockSearchParams('/dashboard');
 
       render(<SignInPage />);
       expect(screen.queryByText(/Please sign in to view your/)).not.toBeInTheDocument();
@@ -232,17 +237,10 @@ describe('SignInPage Component', () => {
     it('shows success toast and redirects to dashboard on successful login', async () => {
       render(<SignInPage />);
 
-      await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-      await userEvent.type(screen.getByLabelText(/Password/i), 'Password123!');
-      await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      await fillAndSubmitLoginForm();
 
       await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith({
-          title: 'Login Success',
-          variant: 'default'
-        });
-
-        expect(mockRouter.push).toHaveBeenCalledWith('/dashboard');
+        expectSuccessfulLogin();
       });
     });
 
@@ -255,20 +253,10 @@ describe('SignInPage Component', () => {
 
       render(<SignInPage />);
 
-      await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-      await userEvent.type(
-        screen.getByLabelText(/Password/i),
-        'WrongPassword123!'
-      );
-      await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      await fillAndSubmitLoginForm('user@example.com', 'WrongPassword123!');
 
       await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith({
-          title: 'Login Failure, please check your email and password',
-          variant: 'destructive'
-        });
-
-        expect(mockRouter.push).not.toHaveBeenCalled();
+        expectFailedLogin();
       });
     });
 
@@ -281,41 +269,23 @@ describe('SignInPage Component', () => {
 
       render(<SignInPage />);
 
-      await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-      await userEvent.type(screen.getByLabelText(/Password/i), 'Password123!');
-      await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      await fillAndSubmitLoginForm();
 
       await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith({
-          title: 'Login Failure, please check your email and password',
-          variant: 'destructive'
-        });
-
-        expect(mockRouter.push).not.toHaveBeenCalled();
+        expectFailedLogin();
       });
     });
 
     it('shows success toast with custom callback URL redirect', async () => {
       // Mock a different callback URL
-      mockSearchParams.get.mockImplementation(param => {
-        if (param === 'callbackUrl') return '/characters';
-        if (param === 'error') return null;
-        return null;
-      });
+      setupMockSearchParams('/characters');
 
       render(<SignInPage />);
 
-      await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
-      await userEvent.type(screen.getByLabelText(/Password/i), 'Password123!');
-      await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      await fillAndSubmitLoginForm();
 
       await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith({
-          title: 'Login Success',
-          variant: 'default'
-        });
-
-        expect(mockRouter.push).toHaveBeenCalledWith('/characters');
+        expectSuccessfulLogin('/characters');
       });
     });
   });

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { signIn } from 'next-auth/react';
 import { z } from 'zod';
 import { userLoginSchema } from '@/lib/validations/user';
@@ -25,13 +25,35 @@ type FormState = {
   isSubmitting: boolean;
 };
 
+// Utility functions to reduce duplication
+const createZodErrors = (zodError: z.ZodError): FormValidationError[] =>
+  zodError.errors.map(err => ({
+    field: err.path.join('.'),
+    message: err.message,
+  }));
+
+const createGeneralError = (error: unknown): FormValidationError[] => [{
+  field: '',
+  message: error instanceof Error ? error.message : 'An unexpected error occurred',
+}];
+
+const TOAST_MESSAGES = {
+  success: 'Login Success',
+  failure: 'Login Failure, please check your email and password',
+} as const;
+
 export default function SignInPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
+
+  // Utility function to get callback URL parameters
+  const getCallbackUrlParam = useCallback(() =>
+    searchParams.get('callbackUrl') || searchParams.get('next'), [searchParams]);
+
   // Enhanced callback URL validation for Issue #438: Prevent invalid redirects
-  const getValidatedCallbackUrl = () => {
-    const rawCallbackUrl = searchParams.get('callbackUrl') || searchParams.get('next');
+  const getValidatedCallbackUrl = useCallback(() => {
+    const rawCallbackUrl = getCallbackUrlParam();
 
     if (!rawCallbackUrl) {
       return '/dashboard';
@@ -58,13 +80,13 @@ export default function SignInPage() {
       console.warn(`Invalid callback URL format: ${rawCallbackUrl}`, error);
       return '/dashboard';
     }
-  };
+  }, [getCallbackUrlParam]);
 
   const callbackUrl = getValidatedCallbackUrl();
   const error = searchParams.get('error');
 
   // Generate redirect message if user was redirected from a protected route
-  const redirectMessage = getRedirectMessage(searchParams.get('callbackUrl') || searchParams.get('next'));
+  const redirectMessage = getRedirectMessage(getCallbackUrlParam());
 
   const [formState, setFormState] = useState<FormState>({
     success: false,
@@ -72,10 +94,29 @@ export default function SignInPage() {
     isSubmitting: false,
   });
 
+  // Form state utility functions
+  const updateFormState = useCallback((partial: Partial<FormState>) => {
+    setFormState(prev => ({ ...prev, ...partial }));
+  }, []);
+
+  const setFormErrors = useCallback((errors: FormValidationError[]) =>
+    updateFormState({ errors, isSubmitting: false }), [updateFormState]);
+
+  const setFormSuccess = useCallback(() =>
+    updateFormState({ success: true, errors: [], isSubmitting: false }), [updateFormState]);
+
+  // Toast utility function
+  const showToast = useCallback((type: 'success' | 'failure') => {
+    toast({
+      title: TOAST_MESSAGES[type],
+      variant: type === 'success' ? 'default' : 'destructive'
+    });
+  }, [toast]);
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    setFormState(prev => ({ ...prev, isSubmitting: true, errors: [] }));
+    updateFormState({ isSubmitting: true, errors: [] });
 
     try {
       const formData = new FormData(event.currentTarget);
@@ -109,54 +150,22 @@ export default function SignInPage() {
       }
 
       // Success - redirect to callback URL
-      setFormState({
-        success: true,
-        errors: [],
-        isSubmitting: false,
-      });
-
-      // Show success toast
-      toast({
-        title: 'Login Success',
-        variant: 'default'
-      });
-
+      setFormSuccess();
+      showToast('success');
       router.push(callbackUrl as any);
     } catch (error) {
       // Handle Zod validation errors
       if (error instanceof z.ZodError) {
-        setFormState({
-          success: false,
-          errors: error.errors.map(err => ({
-            field: err.path.join('.'),
-            message: err.message,
-          })),
-          isSubmitting: false,
-        });
+        setFormErrors(createZodErrors(error));
         return;
       }
 
       // Handle other errors
-      setFormState({
-        success: false,
-        errors: [
-          {
-            field: '',
-            message:
-              error instanceof Error
-                ? error.message
-                : 'An unexpected error occurred',
-          },
-        ],
-        isSubmitting: false,
-      });
+      setFormErrors(createGeneralError(error));
 
       // Show failure toast for authentication errors
       if (error instanceof Error) {
-        toast({
-          title: 'Login Failure, please check your email and password',
-          variant: 'destructive'
-        });
+        showToast('failure');
       }
     }
   };

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -17,6 +17,7 @@ import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle } from 'lucide-react';
 import { getRedirectMessage } from '@/lib/utils/redirect-utils';
+import { useToast } from '@/hooks/use-toast';
 
 type FormState = {
   success: boolean;
@@ -27,6 +28,7 @@ type FormState = {
 export default function SignInPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { toast } = useToast();
   // Enhanced callback URL validation for Issue #438: Prevent invalid redirects
   const getValidatedCallbackUrl = () => {
     const rawCallbackUrl = searchParams.get('callbackUrl') || searchParams.get('next');
@@ -113,6 +115,12 @@ export default function SignInPage() {
         isSubmitting: false,
       });
 
+      // Show success toast
+      toast({
+        title: 'Login Success',
+        variant: 'default'
+      });
+
       router.push(callbackUrl as any);
     } catch (error) {
       // Handle Zod validation errors
@@ -142,6 +150,14 @@ export default function SignInPage() {
         ],
         isSubmitting: false,
       });
+
+      // Show failure toast for authentication errors
+      if (error instanceof Error) {
+        toast({
+          title: 'Login Failure, please check your email and password',
+          variant: 'destructive'
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
Implements toast notifications for login success and failure as specified in Issue #470.

## Changes Made
- **Success Toast**: Shows "Login Success" message when authentication succeeds
- **Failure Toast**: Shows "Login Failure, please check your email and password" when authentication fails
- **Integration**: Uses existing useToast hook and Sonner library
- **User Experience**: Maintains existing redirect behavior after successful login
- **Error Handling**: Provides user-friendly failure messages for all authentication errors

## Technical Implementation
- Added useToast hook import and initialization in SignIn component
- Implemented success toast display before redirect to callback URL
- Implemented failure toast display for all authentication errors
- Added comprehensive test coverage for toast functionality

## Test Coverage
Added 4 new test cases in SignInPage.test.tsx:
- ✅ Success toast with dashboard redirect
- ✅ Failure toast for invalid credentials  
- ✅ Failure toast for other authentication errors
- ✅ Success toast with custom callback URL redirect

## Quality Assurance
- ✅ All existing tests pass
- ✅ ESLint clean (no warnings or errors)
- ✅ TypeScript compilation successful
- ✅ Production build successful
- ✅ Follows TDD methodology (tests written first)

## Related Issue
CLOSES: #470

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>