### PR TITLE
fix: resolve markdownlint test execution failure

### DIFF
--- a/src/__tests__/markdown-linting.test.js
+++ b/src/__tests__/markdown-linting.test.js
@@ -37,8 +37,9 @@ describe('Markdown Linting', () => {
     keyFiles.forEach(file => {
       test(`${file} should pass markdownlint`, () => {
         expect(() => {
-          // Use spawnSync with array arguments to prevent command injection
-          const result = spawnSync('npx', ['markdownlint', file], { stdio: 'pipe' });
+          // Use local markdownlint-cli installation to prevent npx issues
+          const markdownlintPath = path.join(process.cwd(), 'node_modules', '.bin', 'markdownlint');
+          const result = spawnSync(markdownlintPath, [file], { stdio: 'pipe' });
           if (result.status !== 0) {
             throw new Error(`markdownlint failed for ${file}: ${result.stderr?.toString()}`);
           }
@@ -54,8 +55,9 @@ describe('Markdown Linting', () => {
       fs.writeFileSync(tempFile, testMarkdown);
 
       expect(() => {
-        // Use spawnSync with array arguments to prevent command injection
-        const result = spawnSync('npx', ['markdownlint', tempFile], { stdio: 'pipe' });
+        // Use local markdownlint-cli installation to prevent npx issues
+        const markdownlintPath = path.join(process.cwd(), 'node_modules', '.bin', 'markdownlint');
+        const result = spawnSync(markdownlintPath, [tempFile], { stdio: 'pipe' });
         if (result.status !== 0) {
           throw new Error(`markdownlint failed: ${result.stderr?.toString()}`);
         }
@@ -70,8 +72,9 @@ describe('Markdown Linting', () => {
       fs.writeFileSync(tempFile, testMarkdown);
 
       expect(() => {
-        // Use spawnSync with array arguments to prevent command injection
-        const result = spawnSync('npx', ['markdownlint', tempFile], { stdio: 'pipe' });
+        // Use local markdownlint-cli installation to prevent npx issues
+        const markdownlintPath = path.join(process.cwd(), 'node_modules', '.bin', 'markdownlint');
+        const result = spawnSync(markdownlintPath, [tempFile], { stdio: 'pipe' });
         if (result.status !== 0) {
           throw new Error(`markdownlint failed: ${result.stderr?.toString()}`);
         }


### PR DESCRIPTION
## Summary
Fixes the failing markdown linting tests by replacing npx markdownlint calls with direct local binary paths.

## Problem
The markdown-linting.test.js was failing because:
- Tests were using `npx markdownlint` which couldn't determine the executable
- The markdownlint-cli package wasn't properly installed/accessible via npx

## Solution
- Reinstalled markdownlint-cli dependency
- Updated test to use local binary path: `node_modules/.bin/markdownlint`
- Applied fix to all test cases consistently

## Testing
- ✅ markdown-linting.test.js now passes
- ✅ All quality checks pass
- ✅ Build completes successfully
- ✅ Markdownlint runs correctly via npm script

## Related Issue
CLOSES: #531

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>